### PR TITLE
Enable Carpet Layers compat (#75)

### DIFF
--- a/src/main/java/com/chimericdream/minekea/block/building/covers/GenericCoverBlock.java
+++ b/src/main/java/com/chimericdream/minekea/block/building/covers/GenericCoverBlock.java
@@ -49,16 +49,19 @@ public class GenericCoverBlock extends CarpetBlock implements MinekeaBlock, Wate
         super(settings);
 
         this.setDefaultState(
-            this.stateManager.getDefaultState()
+            this.getDefaultState()
                 .with(FACING, Direction.NORTH)
                 .with(WATERLOGGED, false)
         );
     }
 
+    @Override
     protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+        super.appendProperties(builder);
         builder.add(FACING, WATERLOGGED);
     }
 
+    @Override
     public BlockState getPlacementState(ItemPlacementContext ctx) {
         return (BlockState) this.getDefaultState().with(FACING, ctx.getPlayerFacing().getOpposite())
             .with(WATERLOGGED, ctx.getWorld().getFluidState(ctx.getBlockPos()).getFluid() == Fluids.WATER);


### PR DESCRIPTION
Closes #75 

This pr should not modify normal behaviors since:
- In the constructor, the `super(settings);` call already sets `this.getDefaultState()` to be equal to `this.stateManager.getDefaultState()`, so they are functionally the same unless another mod modifies `CarpetBlock`'s constructor.
- `super.appendProperties(builder);` does not do anything unless another mod modifies it.

Only drawback is that it multiplies the amount of blockstates cover blocks have by 16 if Carpet Layers is present even though they are unusable. Other than that, the 2 mods work together as expected.